### PR TITLE
Closes #4 - Add support for dark theme

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -11,3 +11,49 @@ img.rounded-corners {
     padding-left: 20px;
     padding-right: 20px;
 }
+
+
+
+body.dark-theme {
+  background: #202124;
+  color: #eee;
+}
+
+body.dark-theme table.dataTable.stripe tbody tr.odd, body.dark-theme table.dataTable.display tbody tr.odd {
+  background: rgba(255, 255, 255, .1);
+}
+
+body.dark-theme table.dataTable.stripe tbody tr.even, body.dark-theme table.dataTable.display tbody tr.even {
+  background: rgba(255, 255, 255, .2);
+}
+body.dark-theme table.dataTable.display tbody tr.even>.sorting_1,
+body.dark-theme table.dataTable.order-column.stripe tbody tr.even>.sorting_1,
+body.dark-theme table.dataTable.display tbody tr.odd>.sorting_1,
+body.dark-theme table.dataTable.order-column.stripe tbody tr.odd>.sorting_1 {
+  background: rgba(255, 255, 255, .1);
+}
+
+body.dark-theme .dataTables_wrapper .dataTables_length,
+body.dark-theme .dataTables_wrapper .dataTables_filter,
+body.dark-theme .dataTables_wrapper .dataTables_info,
+body.dark-theme .dataTables_wrapper .dataTables_processing,
+body.dark-theme .dataTables_wrapper .dataTables_paginate {
+  color: #eee;
+}
+
+body.dark-theme table.dataTable thead th,
+body.dark-theme table.dataTable thead td {
+  border-color: #eee;
+}
+
+body.dark-theme .github-cat{
+  fill: rgba(255,255,255,.2) !important;
+}
+
+.theme-toggle {
+  position: absolute;
+  top: 0;
+  left: 0;
+  padding: 10px;
+  cursor: pointer;
+}

--- a/index.html
+++ b/index.html
@@ -53,7 +53,26 @@
     </tfoot>
 </table>
 
-<a href="https://github.com/nilicule/StadiaGameDB" class="github-corner" aria-label="View source on GitHub"><svg width="80" height="80" viewBox="0 0 250 250" style="fill:#151513; color:#fff; position: absolute; top: 0; border: 0; right: 0;" aria-hidden="true"><path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path><path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path><path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path></svg></a><style>.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}</style>
+<a href="https://github.com/nilicule/StadiaGameDB" class="github-corner" aria-label="View source on GitHub"><svg width="80" height="80" viewBox="0 0 250 250" style="fill:#151513; color:#fff; position: absolute; top: 0; border: 0; right: 0;" aria-hidden="true" class="github-cat"><path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path><path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path><path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path></svg></a><style>.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}</style>
 
+<div class="theme-toggle" id="themeToggle">
+  <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-moon"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path></svg>
+</div>
+<script>
+  (function(){
+    if(localStorage.getItem('theme')) {
+      document.body.classList.add('dark-theme');
+    }
+    document.getElementById('themeToggle').addEventListener('click', () => {
+    if(document.body.classList.contains('dark-theme')) {
+      document.body.classList.remove('dark-theme');
+      localStorage.removeItem('theme', 'dark')
+    } else {
+      document.body.classList.add('dark-theme');
+      localStorage.setItem('theme', 'dark')
+    }
+  });
+  }())
+</script>
 </body>
 </html>


### PR DESCRIPTION
I have created a dark theme based on the official Stadia stora page.
Added an icon in the top left corner to toggle between dark and light theme.

The selected theme will also be stored in localStorage so it will be remembered on the device you use.

![image](https://user-images.githubusercontent.com/1274603/79642891-47593300-81a0-11ea-8f8b-56590bc56c6a.png)
