### PR TITLE
Fix syntax error in uuidmap.json

### DIFF
--- a/data/uuidmap.json
+++ b/data/uuidmap.json
@@ -68,6 +68,6 @@
         "c911998e4f8d4c6ea6712c5ad33e4a54rcp1": 65,
         "f5f9708a422a44cc876c240cfa07221drcp1": 66,
         "8e77c7a4368944589b4c9d8179d2eb4crcp1": 67,
-        "ed05d9df2ec4452594b07336e360a1aarcp1", 68
+        "ed05d9df2ec4452594b07336e360a1aarcp1": 68
     }
 }


### PR DESCRIPTION
Fix JSON syntax error in uuidmap. This is currently preventing the Stadia+ extension from working correctly.